### PR TITLE
[ZAIR-136] Admin > Hidden fields when not required

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -179,7 +179,7 @@ class Data extends AbstractHelper
      */
     public function getZaiusTrackerId($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/zaius_tracker_id', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/status/zaius_tracker_id', 'store', $store);
     }
 
     /**
@@ -188,7 +188,7 @@ class Data extends AbstractHelper
      */
     public function getZaiusPrivateKey($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/zaius_private_api', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/status/zaius_private_api', 'store', $store);
     }
 
     /**
@@ -197,7 +197,7 @@ class Data extends AbstractHelper
      */
     public function getAmazonS3Status($store = null)
     {
-        return $this->scopeConfig->isSetFlag('zaius_engage/config/amazon_active', 'store', $store);
+        return $this->scopeConfig->isSetFlag('zaius_engage/amazon/active', 'store', $store);
     }
 
     /**
@@ -206,7 +206,7 @@ class Data extends AbstractHelper
      */
     public function getAmazonS3Key($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/amazon_s3_key', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/amazon/s3_key', 'store', $store);
     }
 
     /**
@@ -215,7 +215,7 @@ class Data extends AbstractHelper
      */
     public function getAmazonS3Secret($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/amazon_s3_secret', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/amazon/s3_secret', 'store', $store);
     }
 
     /**

--- a/Helper/Sdk.php
+++ b/Helper/Sdk.php
@@ -101,7 +101,7 @@ class Sdk
      */
     public function getZaiusTrackerId($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/zaius_tracker_id', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/status/zaius_tracker_id', 'store', $store);
     }
 
     /**
@@ -110,6 +110,6 @@ class Sdk
      */
     public function getZaiusPrivateKey($store = null)
     {
-        return $this->scopeConfig->getValue('zaius_engage/config/zaius_private_api', 'store', $store);
+        return $this->scopeConfig->getValue('zaius_engage/status/zaius_private_api', 'store', $store);
     }
 }

--- a/Model/ConfigurationRepository.php
+++ b/Model/ConfigurationRepository.php
@@ -120,7 +120,7 @@ class ConfigurationRepository implements ConfigurationInterface
 
             $storeConfig = $this->_scopeConfig->getValue('zaius_engage', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeCode);
             $inStoreConfigArray = $this->_scopeConfig->getValue(
-                    'zaius_engage/config/zaius_tracker_id',
+                    'zaius_engage/status/zaius_tracker_id',
                     \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                     $storeCode
                 ) === $trackingID;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -12,64 +12,74 @@
 
             <group id="status" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Zaius Engage Status</label>
-                <field id="status" translate="label" type="select" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="status" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enabled?</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="version" translate="label" type="label" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="version" translate="label" type="label" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Version</label>
                     <frontend_model>Zaius\Engage\Block\System\Config\Version</frontend_model>
                     <comment>
                         Zaius Engage Version
                     </comment>
                 </field>
-                <field id="composer" translate="label" type="label" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="composer" translate="label comment" type="label" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Composer Installed?</label>
                     <frontend_model>Zaius\Engage\Block\System\Config\Sdk</frontend_model>
                     <comment>
                         Checks if Composer is installed.
                     </comment>
                 </field>
-                <field id="sdk" translate="label comment" type="label" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="sdk" translate="label comment" type="label" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>SDK Installed?</label>
                     <frontend_model>Zaius\Engage\Block\System\Config\Sdk</frontend_model>
                     <comment>
                         Checks if the Zaius SDK is installed.
                     </comment>
                 </field>
-            </group>
-
-            <group id="config" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Configuration</label>
-                <field id="zaius_tracker_id" translate="label comment" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="zaius_tracker_id" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Zaius Tracker ID</label>
                     <comment><![CDATA[
                 Found at: <a href="https://app.zaius.com/app?scope=731#/api_management" target="_blank">API Management</a> in your Zaius Account. ]]>
                     </comment>
+                    <validate>required-entry</validate>
+                    <depends>
+                        <field id="*/*/status">1</field>
+                    </depends>
                 </field>
-                <field id="zaius_private_api" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="zaius_private_api" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Zaius Private API Key</label>
                     <comment><![CDATA[
                 Found at: <a href="https://app.zaius.com/app?scope=731#/api_management" target="_blank">API Management</a> in your Zaius Account. ]]>
                     </comment>
+                    <validate>required-entry</validate>
+                    <depends>
+                        <field id="*/*/status">1</field>
+                    </depends>
                 </field>
-                <field id="amazon_active" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+            </group>
+
+            <group id="amazon" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Amazon S3</label>
+                <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enabled Amazon S3</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="amazon_s3_key" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="s3_key" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Amazon S3 Key</label>
+                    <validate>required-entry</validate>
                     <depends>
-                        <field id="*/*/amazon_active">1</field>
+                        <field id="*/*/active">1</field>
                     </depends>
                     <comment><![CDATA[
                 Found at: <a href="https://app.zaius.com/app?scope=731#/integrations?activeTab=amazon_s3" target="_blank">Integrations</a> in your Zaius Account. ]]>
                     </comment>
                 </field>
-                <field id="amazon_s3_secret" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="s3_secret" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Amazon S3 Secret</label>
+                    <validate>required-entry</validate>
                     <depends>
-                        <field id="*/*/amazon_active">1</field>
+                        <field id="*/*/active">1</field>
                     </depends>
                     <comment><![CDATA[
                 Found at: <a href="https://app.zaius.com/app?scope=731#/integrations?activeTab=amazon_s3" target="_blank">Integrations</a> in your Zaius Account. ]]>


### PR DESCRIPTION
# Not saving 

#### Cause
It was caused by a hidden field which was required and the user didn't see.

# My Pull Request
@travish already had added the store scope feature into the code, so I changed the XML code to:

- Hide fields when not required (e.g not enabled)
- When enable require the key fields
- Not allow saving if the user enables and didn't fill the key fields.

## Benefits

- The user can save without keys 
- Fewer fields to show when it's not required.
- Less code verification required from our side.
- Delegate the validation to the Magento side.
- The same patterns as the core modules.
- More compatibility between the versions.

https://www.loom.com/share/5c95020a918e481cae728de23f215cad

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/zaius-magento-2/7)
<!-- Reviewable:end -->
