### PR TITLE
[ZAIR-136] Setup > Transfer the old path config to the new one

### DIFF
--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -3,10 +3,12 @@
 namespace Zaius\Engage\Setup;
 
 use Magento\Framework\Setup\InstallSchemaInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\Framework\Module\ResourceInterface as ModuleResourceInterface;
+use Zend_Db_Statement_Exception;
 
 /**
  * Class Recurring
@@ -14,6 +16,8 @@ use Magento\Framework\Module\ResourceInterface as ModuleResourceInterface;
  */
 class Recurring implements InstallSchemaInterface
 {
+    const CONFIG_TABLE = 'core_config_data';
+
     /**
      * @var ZAIUS
      */
@@ -29,23 +33,32 @@ class Recurring implements InstallSchemaInterface
     protected $_resource;
 
     /**
+     * @var ModuleDataSetupInterface
+     */
+    private $setup;
+
+    /**
      * Recurring constructor.
      * @param ModuleListInterface $list
      * @param ModuleResourceInterface $resource
+     * @param ModuleDataSetupInterface $setup
      */
     public function __construct(
         ModuleListInterface $list,
-        ModuleResourceInterface $resource
-    )
-    {
+        ModuleResourceInterface $resource,
+        ModuleDataSetupInterface $setup
+    ) {
         $this->_list = $list;
         $this->_resource = $resource;
+        $this->setup = $setup;
     }
+
     /**
-     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup
-     * @param \Magento\Framework\Setup\ModuleContextInterface $context
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @throws Zend_Db_Statement_Exception
      */
     public function install(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -58,6 +71,56 @@ class Recurring implements InstallSchemaInterface
             $this->_resource->setDataVersion(self::ZAIUS, $setup_version); //data_version
             $this->_resource->setDbVersion(self::ZAIUS, $setup_version); //schema_version
         }
+
+        $this->changeConfigPosition($setup, 'zaius_engage/config/zaius_tracker_id', 'zaius_engage/status/zaius_tracker_id', true);
+        $this->changeConfigPosition($setup, 'zaius_engage/config/zaius_private_api', 'zaius_engage/status/zaius_private_api', true);
+
         $update->endSetup();
+    }
+
+    /**
+     * Transfer an old salved config to a new config path
+     *
+     * @param SchemaSetupInterface $setup
+     * @param $oldConfigPath
+     * @param $newConfigPath
+     * @param bool $removeOldConfig
+     * @throws Zend_Db_Statement_Exception
+     */
+    protected function changeConfigPosition(SchemaSetupInterface $setup, $oldConfigPath, $newConfigPath, $removeOldConfig = true)
+    {
+        $selectOldTrackerId = $setup->getConnection()->select()
+            ->from($this->setup->getTable(self::CONFIG_TABLE))
+            ->where("path = ?", $oldConfigPath);
+        $selectAllOldValues = $setup->getConnection()->query($selectOldTrackerId)->fetchAll();
+        if (array_count_values($selectOldTrackerId->getBind()) > 0) {
+            foreach ($selectAllOldValues as $oldConfig) {
+                $path = str_replace($oldConfigPath, $newConfigPath, $oldConfig['path']);
+                $this->saveConfigValue($path, $oldConfig['value'], $oldConfig['scope'], $oldConfig['scope_id']);
+            }
+        }
+        if ($removeOldConfig) {
+            $selectRemoveOldVal = $setup->getConnection()->deleteFromSelect($selectOldTrackerId, $this->setup->getTable(self::CONFIG_TABLE));
+            $setup->getConnection()->query($selectRemoveOldVal);
+        }
+    }
+
+    /**
+     * Save a new configuration into the core_config_data
+     * @param $path
+     * @param $value
+     * @param string $scope
+     * @param int $scopeid
+     */
+    protected function saveConfigValue($path, $value, $scope = 'default', $scopeid = 0)
+    {
+        $data = [
+            'scope' => $scope,
+            'scope_id' => $scopeid,
+            'path' => $path,
+            'value' => $value,
+        ];
+        $this->setup->getConnection()
+            ->insertOnDuplicate($this->setup->getTable(self::CONFIG_TABLE), $data, ['value']);
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Zaius_Engage" setup_version="1.0.0-RC.5">
+  <module name="Zaius_Engage" setup_version="1.0.0-RC.6">
     <sequence>
       <module name="Magento_Catalog"/>
       <module name="Magento_CatalogSearch"/>


### PR DESCRIPTION
To avoid keeping the old data hidden in the database I implemented a check during the updates if there is an old data when the extension updates, the old data will be moved to the new path and removed from the old one. So, it will avoid running a data schema update on-the-fly.

We will have to [migrate install/upgrade scripts to the declarative schema](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/migration-commands.html) soon as Magento did the core modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/zaius-magento-2/8)
<!-- Reviewable:end -->
