### PR TITLE
[ZAIR-143] Remove Tracking Orders on the Frontend

### DIFF
--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -74,6 +74,7 @@ class Recurring implements InstallSchemaInterface
 
         $this->changeConfigPosition($setup, 'zaius_engage/config/zaius_tracker_id', 'zaius_engage/status/zaius_tracker_id', true);
         $this->changeConfigPosition($setup, 'zaius_engage/config/zaius_private_api', 'zaius_engage/status/zaius_private_api', true);
+        $this->saveConfigValue('zaius_engage/settings/is_tracking_orders_on_frontend', 0);
 
         $update->endSetup();
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -101,8 +101,9 @@
                         Specify a Newsletter List ID.
                     </comment>
                 </field>
-                <field id="is_tracking_orders_on_frontend" translate="label comment" type="select" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="is_tracking_orders_on_frontend" translate="label comment" type="select" sortOrder="0" showInDefault="0" showInWebsite="0" showInStore="0">
                     <label>Track Orders on Frontend</label>
+<!--                    <frontend_class>hidden</frontend_class>-->
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
                         Choose if you want to track orders.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -103,7 +103,6 @@
                 </field>
                 <field id="is_tracking_orders_on_frontend" translate="label comment" type="select" sortOrder="0" showInDefault="0" showInWebsite="0" showInStore="0">
                     <label>Track Orders on Frontend</label>
-<!--                    <frontend_class>hidden</frontend_class>-->
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
                         Choose if you want to track orders.


### PR DESCRIPTION
**Phase I** 

1. Hide the setting in the config to "Track Orders on Frontend".
2. Make sure the setting in the DB config path is set to reflect this setting as false.

**Phase II**

PR: https://github.com/ZaiusInc/zaius-magento-2/pull/10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/zaius-magento-2/9)
<!-- Reviewable:end -->
