### PR TITLE
ZAIUS-12634: Changed default vtsrc variable to empty array instead of null

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -395,7 +395,7 @@ class Data extends AbstractHelper
     public function getVTSRC()
     {
         $vtsrcCookie = $this->_cookieManager->getCookie('vtsrc');
-        $vtsrc = null;
+        $vtsrc = [];
         if ($vtsrcCookie) {
             $vtsrc = $this->prepareVtsrc($vtsrcCookie);
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -390,7 +390,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @return null|array
+     * @return array
      */
     public function getVTSRC()
     {


### PR DESCRIPTION
This fixes an error that appeared in the logs for Golf Discount's Magento 2 connector, as per https://zaius-jira.atlassian.net/browse/ZAIUS-12634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/zaius-magento-2/65)
<!-- Reviewable:end -->
