### PR TITLE
fix infinite loop in checkout error

### DIFF
--- a/Observer/CartRemoveObserver.php
+++ b/Observer/CartRemoveObserver.php
@@ -58,7 +58,7 @@ class CartRemoveObserver
 
     /**
      * @param Observer $observer
-     * @param null $item
+     * @param Quote\Item|null $item
      * @param null $info
      * @return $this|void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
@@ -66,11 +66,6 @@ class CartRemoveObserver
     public function execute(Observer $observer, $item = null, $info = null)
     {
         if ($this->_helper->getStatus($this->_storeManager->getStore())) {
-            /** @var Quote $quote */
-            $quote = $this->_checkoutSession->getQuote();
-            if (empty($quote->getCreatedAt())) {
-                $quote = $quote->load($quote->getId());
-            }
             $action = 'update_qty';
             if (is_null($item)) {
                 /** @var QuoteItem $item */
@@ -79,7 +74,9 @@ class CartRemoveObserver
                 $action = 'remove_from_cart';
             }
 
-            /** @var Product $item */
+            /** @var Quote $quote */
+            $quote = $item->getQuote();
+
             // when working with configurable/simple products, product/item models grab the configurable parent of a
             // simple product, but contain the sku of the simple product. We need to grab that sku, and load the simple
             // product model for processing to Zaius.

--- a/Observer/CartUpdateObserver.php
+++ b/Observer/CartUpdateObserver.php
@@ -93,7 +93,7 @@ class CartUpdateObserver
                 $product = $item->getProduct();
                 if (isset($info[$item->getId()]) && $item->getQty() != $info[$item->getId()]['qty']) {
                     if ($item->getQty() > $info[$item->getId()]['qty']) {
-                        $this->_cartRemove->execute($observer, $product, $info);
+                        $this->_cartRemove->execute($observer, $item, $info);
                     }
                     if ($item->getQty() < $info[$item->getId()]['qty']) {
                         $this->_cartAdd->execute($observer, $product, $info);


### PR DESCRIPTION
I found that the error "Infinite loop detected, review the trace for the looping path" is being thrown in the following file: vendor/magento/module-checkout/Model/Session.php:241

And that is happening because CartRemoveObserver was trying to fetch the Quote from the Checkout Session while it was still processing. Since getting the Quote from the session is a bit redundant having the QuoteItem already, I removed those lines of code and retrieved the Quote from the QuoteItem object.